### PR TITLE
Avoid warning on crossOrigin attribute

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -6,7 +6,7 @@ exports.onRenderBody = ({ setHeadComponents }) => {
     rel: 'stylesheet',
     href: 'https://unpkg.com/leaflet@1.3.3/dist/leaflet.css',
     integrity: 'sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ==',
-    crossorigin: ''
+    crossOrigin: ''
   })
 
   setHeadComponents([


### PR DESCRIPTION
When using this module, we have a warning because of case issue on crossOrigin.

Warning: Invalid DOM property `crossorigin`. Did you mean `crossOrigin`?
    in link
    in head
    in html
    in HTML