### PR TITLE
Remove react-leaflet from webpack null loader config

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -4,9 +4,7 @@ exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
   if (stage === "build-html") {
     const regex = [
       /node_modules\/leaflet/,
-      /node_modules\/react-leaflet/,
-      /node_modules\\leaflet/,
-      /node_modules\\react-leaflet/
+      /node_modules\\leaflet/
     ]
     actions.setWebpackConfig({
       module: {


### PR DESCRIPTION
Via https://github.com/dweirich/gatsby-plugin-react-leaflet/issues/15

It doesn't seem like `react-leaflet` is actually needed in the null loader configuration as multiple sources have confirmed able to run and build without it.

Keeping it out helps provide functionality core to `react-leaflet` such as extending components for custom solutions, where setting the loader to null prevents that - see: https://github.com/PaulLeCam/react-leaflet/issues/645