### PR TITLE
feat: fix loading of leaflet in `develop` mode

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
 exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
-  if (stage === "build-html") {
+  if (stage === "build-html" || stage === "develop-html") {
     const regex = [
       /node_modules\/leaflet/,
       /node_modules\\leaflet/


### PR DESCRIPTION
Seconds after opening #17, I found out that I was correct, and also found a way to fix it.

It turns out, the build stage for `gatsby develop` has a different name than the one for `gatsby build`.

With this small change, leaflet components are also stubbed in `develop` mode.

---
fixes #17