### PR TITLE
Use array for loaders

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -11,7 +11,7 @@ exports.onCreateWebpackConfig = ({
       module: {
         rules: [{
           test: regex,
-          use: loaders.null()
+          use: [loaders.null()]
         }]
       }
     });


### PR DESCRIPTION
Fix `TypeError: loaders is not iterable` issue with webpack 5