### PR TITLE
Update gatsby peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "David Weirich",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0",
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "leaflet": "^1.7.1",
     "react-leaflet": "^3.0.0"
   },


### PR DESCRIPTION
Gatsby 4 was released on Oct 25, 2021. Since then projects using this plugin got a warning message.
This means projects may already use the latest gatsby version with this plugin. As there are currently no 
open issues for known compatibility errors open it should be safe to update the peer dependency.

Fixes #25